### PR TITLE
Increment 24: Add a check that the agent's ip-address is part of a trusted subnet

### DIFF
--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -1,6 +1,9 @@
 package main
 
-import "time"
+import (
+	"net"
+	"time"
+)
 
 type Config struct {
 	serverAddr      string        // serverAddr store address and port to send requests to a server
@@ -10,6 +13,7 @@ type Config struct {
 	privateKeyPath  string        // Путь до файла с приватным ключом
 	logLevel        string        //
 	configFile      string        // Путь к файлу конфигурации
+	trustedSubnet   *net.IPNet    // Доверенная подсеть
 	storeInterval   time.Duration // Периодичность, с которой текущие показания сервера сохраняются на диск (в секундах)
 	isReqRestore    bool          // Загружать ранее сохранённые значения из файла при старте сервера
 }
@@ -90,4 +94,27 @@ func (c Config) PrivateKeyPath() string {
 func (c Config) SetPrivateKeyPath(path string) Config {
 	c.privateKeyPath = path
 	return c
+}
+
+func (c Config) TrustedSubnet() *net.IPNet {
+	return c.trustedSubnet
+}
+
+func (c Config) SetTrustedSubnet(subnet *net.IPNet) Config {
+	c.trustedSubnet = subnet
+	return c
+}
+
+func (c Config) SetTrustedSubnetFromString(subnet string) (Config, error) {
+	if subnet == "" {
+		return c, nil
+	}
+
+	_, s, err := net.ParseCIDR(subnet)
+	if err != nil {
+		return c, err
+	}
+
+	c.trustedSubnet = s
+	return c, nil
 }

--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -12,17 +12,17 @@ import (
 
 func loadConfig() (conf Config, err error) {
 	conf = NewConfig()
-	conf = parseFlags(conf)
+	conf, err = parseFlags(conf)
+	if err != nil {
+		return
+	}
+
 	conf, err = parseEnvs(conf)
 	if err != nil {
 		return
 	}
 
 	conf, err = parseConfigFile(conf)
-	if err != nil {
-		return
-	}
-
 	return
 }
 
@@ -66,6 +66,10 @@ func parseConfigFile(config Config) (Config, error) {
 		config.privateKeyPath = cf.privateKeyPath
 	}
 
+	if config.trustedSubnet.String() == defaults.trustedSubnet.String() && cf.trustedSubnet.String() != defaults.trustedSubnet.String() {
+		config.trustedSubnet = cf.trustedSubnet
+	}
+
 	return config, nil
 }
 
@@ -82,6 +86,7 @@ func loadConfigFile(path string, config Config) (Config, error) {
 		StoreFile     string `json:"store_file,omitempty"`
 		DatabaseDSN   string `json:"database_dsn,omitempty"`
 		CryptoKey     string `json:"crypto_key,omitempty"`
+		TrustedSubnet string `json:"trusted_subnet,omitempty"`
 	}
 	var conf Conf
 	if err = json.Unmarshal(data, &conf); err != nil {
@@ -114,10 +119,17 @@ func loadConfigFile(path string, config Config) (Config, error) {
 		config = config.SetPrivateKeyPath(conf.CryptoKey)
 	}
 
+	if conf.TrustedSubnet != "" {
+		config, err = config.SetTrustedSubnetFromString(conf.TrustedSubnet)
+		if err != nil {
+			return config, fmt.Errorf("failed to parse subnet in trusted_subnet when processing config file: %w", err)
+		}
+	}
+
 	return config, nil
 }
 
-func parseFlags(config Config) Config {
+func parseFlags(config Config) (Config, error) {
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
 	// Флаг -a=<ЗНАЧЕНИЕ> отвечает за адрес эндпоинта HTTP-сервера (по умолчанию localhost:8080).
@@ -143,12 +155,27 @@ func parseFlags(config Config) Config {
 	// Флаг -crypto-key путь до файла с приватным ключом
 	privateKeyPath := flag.String("crypto-key", config.privateKeyPath, "Path to the private key file")
 
+	// Строковое представление бесклассовой адресации (CIDR).
+	var t string
+	if config.trustedSubnet != nil {
+		t = config.trustedSubnet.String()
+	}
+	trustedSubnet := flag.String("t", t, "Trusted subnet (CIDR)")
+
 	// Флаг -config путь к файлу конфигурации
 	const configUsage = "Path to the config file"
 	flag.StringVar(&config.configFile, "config", "", configUsage)
 	flag.StringVar(&config.configFile, "c", "", configUsage+" (shorthand)")
 
 	flag.Parse()
+
+	if *trustedSubnet != "" {
+		c, err := config.SetTrustedSubnetFromString(*trustedSubnet)
+		if err != nil {
+			return config, fmt.Errorf("failed to parse trusted subnet: %w", err)
+		}
+		config = c
+	}
 
 	return config.
 		SetServerAddr(*serverAddr).
@@ -157,7 +184,7 @@ func parseFlags(config Config) Config {
 		SetIsReqRestore(*isReqRestore).
 		SetDatabaseDSN(*databaseDSN).
 		SetSecretKey(*secretKey).
-		SetPrivateKeyPath(*privateKeyPath)
+		SetPrivateKeyPath(*privateKeyPath), nil
 }
 
 func parseEnvs(config Config) (Config, error) {
@@ -167,6 +194,7 @@ func parseEnvs(config Config) (Config, error) {
 		DatabaseDSN     string `env:"DATABASE_DSN"`
 		SecretKey       string `env:"KEY"`
 		PrivateKeyPath  string `env:"CRYPTO_KEY"`
+		TrustedSubnet   string `env:"TRUSTED_SUBNET"`
 		ConfigFile      string `env:"CONFIG"`
 		StoreInterval   uint   `env:"STORE_INTERVAL"`
 		IsReqRestore    bool   `env:"RESTORE"`
@@ -202,6 +230,14 @@ func parseEnvs(config Config) (Config, error) {
 
 	if _, exists := os.LookupEnv("CRYPTO_KEY"); exists {
 		config = config.SetPrivateKeyPath(cfg.PrivateKeyPath)
+	}
+
+	if _, exists := os.LookupEnv("TRUSTED_SUBNET"); exists {
+		c, err := config.SetTrustedSubnetFromString(cfg.TrustedSubnet)
+		if err != nil {
+			return config, fmt.Errorf("failed to parse trusted subnet: %w", err)
+		}
+		config = c
 	}
 
 	if _, exists := os.LookupEnv("CONFIG"); exists {

--- a/cmd/server/flags_test.go
+++ b/cmd/server/flags_test.go
@@ -32,6 +32,7 @@ func (suite *FlagsTestSuite) SetupSuite() {
 		"DATABASE_DSN",
 		"KEY",
 		"CRYPTO_KEY",
+		"TRUSTED_SUBNET",
 	} {
 		suite.osEnviron[e] = os.Getenv(e)
 	}
@@ -132,7 +133,8 @@ func (suite *FlagsTestSuite) TestParseFlags() {
 			}
 
 			config := NewConfig()
-			config = parseFlags(config)
+			config, err := parseFlags(config)
+			suite.Require().NoError(err)
 
 			configFields := reflect.ValueOf(config)
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -99,6 +99,7 @@ func runServer(ctx context.Context) {
 	go func() {
 		handlers.SetSecretKey(config.secretKey)
 		handlers.SetPrivateKey(readPrivateKey())
+		handlers.SetTrustedSubnet(config.trustedSubnet)
 		server = http.Server{Addr: config.serverAddr, Handler: handlers.ServerRouter()}
 
 		logger.Log.Info("Running server", logger.String("address", config.serverAddr), logger.String("event", "start server"))

--- a/config-server.json
+++ b/config-server.json
@@ -4,5 +4,6 @@
     "store_interval": "5s",
     "store_file": "d:\\Projects\\go-yandex-advanced\\metrics-db.json",
     "database_dsn": "",
-    "crypto_key": "d:\\Projects\\go-yandex-advanced\\keys\\test-private.pem"
+    "crypto_key": "d:\\Projects\\go-yandex-advanced\\keys\\test-private.pem",
+    "trusted_subnet": "169.254.0.0/16"
 }

--- a/internal/agent/ip.go
+++ b/internal/agent/ip.go
@@ -1,0 +1,42 @@
+package agent
+
+import (
+	"net"
+)
+
+func GetIP() (net.IP, error) {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return nil, err
+	}
+	var l []net.IP
+	var p []net.IP
+
+	for _, addr := range addrs {
+		if ipnet, ok := addr.(*net.IPNet); ok {
+			if ipnet.IP.IsLoopback() && ipnet.IP.To4() != nil {
+				l = append(l, ipnet.IP)
+				continue
+			}
+
+			if ipnet.IP.IsPrivate() && ipnet.IP.To4() != nil {
+				p = append(p, ipnet.IP)
+				continue
+			}
+
+			if ipnet.IP.To4() != nil {
+				return ipnet.IP, nil
+			}
+		}
+	}
+
+	if len(p) > 0 {
+		return p[0], nil
+	}
+
+	if len(l) > 0 {
+		return l[0], nil
+	}
+
+	return nil, nil
+}

--- a/internal/agent/update-metrics.go
+++ b/internal/agent/update-metrics.go
@@ -159,6 +159,13 @@ func workerPostMetrics(ctx context.Context, dataCh <-chan *storage.MemStorage) {
 	client := resty.New().SetBaseURL("http://" + Config.ServerAddr())
 	logger.Log.Info("Running agent worker", logger.String("address", Config.ServerAddr()), logger.String("event", "start agent worker"))
 
+	ip, err := GetIP()
+	if err != nil {
+		logger.Log.Warn(err.Error())
+	} else if ip != nil {
+		client.SetHeader("X-Real-IP", ip.String())
+	}
+
 	gz, err := gzip.NewWriterLevel(nil, gzip.BestCompression)
 	if err != nil {
 		logger.Log.Panic(err.Error())

--- a/internal/handlers/config.go
+++ b/internal/handlers/config.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"net"
+	
 	store "github.com/fishus/go-advanced-metrics/internal/storage"
 )
 
@@ -32,4 +34,14 @@ func PrivateKey() []byte {
 
 func SetPrivateKey(key []byte) {
 	privateKey = key
+}
+
+var trustedSubnet *net.IPNet
+
+func TrustedSubnet() *net.IPNet {
+	return trustedSubnet
+}
+
+func SetTrustedSubnet(subnet *net.IPNet) {
+	trustedSubnet = subnet
 }

--- a/internal/handlers/middleware/trusted-subnet.go
+++ b/internal/handlers/middleware/trusted-subnet.go
@@ -1,0 +1,43 @@
+package middleware
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+func TrustedSubnet(subnet *net.IPNet) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		fn := func(w http.ResponseWriter, r *http.Request) {
+
+			if subnet == nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			contentType := r.Header.Get("Content-Type")
+
+			remoteAddr := r.Header.Get("X-Real-IP")
+			if remoteAddr == "" {
+				ra := strings.Split(r.RemoteAddr, ":")
+				if len(ra) == 2 {
+					remoteAddr = ra[0]
+				}
+			}
+
+			ip := net.ParseIP(remoteAddr)
+
+			if !subnet.Contains(ip) {
+				if strings.Contains(contentType, "application/json") {
+					JSONError(w, "The request from this ip-address was rejected.", http.StatusForbidden)
+				} else {
+					http.Error(w, "The request from this ip-address was rejected.", http.StatusForbidden)
+				}
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		}
+		return http.HandlerFunc(fn)
+	}
+}

--- a/internal/handlers/middleware/trusted-subnet_test.go
+++ b/internal/handlers/middleware/trusted-subnet_test.go
@@ -1,0 +1,82 @@
+package middleware
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-resty/resty/v2"
+	"github.com/stretchr/testify/suite"
+)
+
+type TrustedSubnetSuite struct {
+	suite.Suite
+	ts     *httptest.Server
+	client *resty.Client
+	subnet *net.IPNet
+}
+
+func (s *TrustedSubnetSuite) SetupSuite() {
+	_, subnet, err := net.ParseCIDR("192.168.0.0/24")
+	s.Require().NoError(err)
+	s.subnet = subnet
+
+	r := chi.NewRouter()
+	r.Use(TrustedSubnet(subnet))
+
+	r.Post("/test/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, err := io.Copy(w, r.Body)
+		s.Require().NoError(err)
+	})
+
+	s.ts = httptest.NewServer(r)
+	s.client = resty.New().SetBaseURL(s.ts.URL)
+}
+
+func (s *TrustedSubnetSuite) TearDownSuite() {
+	s.ts.Close()
+}
+
+func (s *TrustedSubnetSuite) sendRequest(ip string) *resty.Response {
+	req := s.client.R().SetHeader("X-Real-IP", ip)
+
+	resp, err := req.Post("test/")
+	s.Require().NoError(err)
+
+	return resp
+}
+
+func (s *TrustedSubnetSuite) TestTrustedSubnet() {
+	testCases := []struct {
+		name string
+		ip   string
+		code int
+	}{
+		{
+			name: "Positive case",
+			ip:   "192.168.0.123",
+			code: 200,
+		},
+		{
+			name: "Negative case",
+			ip:   "127.0.0.1",
+			code: 403,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			resp := s.sendRequest(tc.ip)
+			s.Equal(tc.code, resp.StatusCode())
+		})
+	}
+}
+
+func TestTrustedSubnetSuite(t *testing.T) {
+	suite.Run(t, new(TrustedSubnetSuite))
+}

--- a/internal/handlers/router.go
+++ b/internal/handlers/router.go
@@ -15,11 +15,8 @@ func ServerRouter() chi.Router {
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.RequestID)
 	r.Use(mw.Decompress)
-
-	if len(privateKey) > 0 {
-		r.Use(mw.Decrypt(privateKey))
-	}
-
+	r.Use(mw.TrustedSubnet(trustedSubnet))
+	r.Use(mw.Decrypt(privateKey))
 	r.Use(mw.ValidateSign([]byte(secretKey)))
 	r.Use(mw.Sign([]byte(secretKey)))
 	r.Use(middleware.Compress(9, "application/json", "text/html"))


### PR DESCRIPTION
Добавлен флаг -t и переменная окружения TRUSTED_SUBNET.
В запрос агента добавлен заголовок X-Real-IP, в котором должен содержаться IP-адрес хоста агента.
При отправке метрик агентом сервер проверяет, что переданный в заголовке запроса X-Real-IP ip-адрес агента входит в доверенную подсеть.